### PR TITLE
Fix coverage gate grep pattern in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
         working-directory: skills/${{ matrix.skill }}/reference
         run: |
           # Bun prints coverage as a table. Check for any line below 100%.
-          # Coverage lines look like: "src/file.ts  100.00%  100.00%  100.00%"
+          # Coverage lines look like: "src/file.ts  |  100.00 |  100.00 |"
           # Fail if any source file (not test file) has coverage below 100%.
-          if grep -E '^\s*src/[^.]+\.ts\s' test-output.txt | grep -v '\.test\.ts' | grep -vq '100\.00%.*100\.00%'; then
+          if grep -E '^\s*src/[^.]+\.ts\s' test-output.txt | grep -v '\.test\.ts' | grep -vq '100\.00.*100\.00'; then
             echo "::error::Coverage below 100% detected in ${{ matrix.skill }}"
             grep -E '^\s*src/[^.]+\.ts\s' test-output.txt | grep -v '\.test\.ts'
             exit 1


### PR DESCRIPTION
Bun's coverage output uses "100.00" without percent signs, but the
grep pattern was looking for "100.00%", causing the coverage check
to always fail even when coverage is 100%.

https://claude.ai/code/session_01LEF3kkCoBk3yYKwDtR7yVZ